### PR TITLE
Call authRefresh() to ensure that the loaded cookie is valid

### DIFF
--- a/apps/web/src/hooks.server.ts
+++ b/apps/web/src/hooks.server.ts
@@ -8,6 +8,16 @@ export const handle: Handle = async ({ event, resolve }) => {
 	event.locals.pb = new PocketBase(PUBLIC_PB_HOST);
 	event.locals.pb.authStore.loadFromCookie(event.request.headers.get('cookie') || '');
 
+	try {
+		// get an up-to-date auth store state by veryfing and refreshing the loaded auth model (if any)
+		if (event.locals.pb.authStore.isValid) {
+			await event.locals.pb.collection('users').authRefresh();
+		}
+	} catch (_) {
+		// clear the auth store on failed refresh
+		event.locals.pb.authStore.clear();
+	}
+
 	if (event.locals.pb.authStore.isValid) {
 		event.locals.user = serializeNonPOJOs<User>(event.locals.pb.authStore.model as User);
 	} else {


### PR DESCRIPTION
_This tutorial was mentioned in https://github.com/pocketbase/js-sdk/issues/85._

The PR adds an additional `authRefresh()` call to ensure that the loaded cookie is verified and valid.

This is not an issue on its own if you are sending requests only to the PocketBase server (aka. trying to update a user with fake/invalid token will throw an error), but it is a good idea to validate the loaded auth store state server-side so that you can safely trust the `pb.authStore.isValid` checks (for example if you want to show some private node/3rd party generated content).

_Note1: I haven't run the project locally, so please make sure to test it first before merging._
_Note2: Sometime later this week I'll also update the SDK SSR examples with the above to avoid eventual security issues in user-land code._

